### PR TITLE
Allow referencing external parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,10 +8,16 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -30,12 +36,11 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
  "windows-sys",
 ]
@@ -71,9 +76,25 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "generic-array"
@@ -97,6 +118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,14 +149,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.38.0"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
- "lazy_static",
- "linked-hash-map",
+ "once_cell",
  "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -144,22 +177,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
+name = "linux-raw-sys"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "memchr"
@@ -236,6 +263,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "syn"
@@ -299,6 +345,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -401,67 +460,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.4"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"

--- a/macros/src/codegen/lookahead_optimization.rs
+++ b/macros/src/codegen/lookahead_optimization.rs
@@ -127,7 +127,11 @@ fn resolve_lookaheads(
                 if !seen.insert(name.clone()) {
                     continue;
                 }
-                stack.extend(parser_lookaheads[&name].iter().cloned());
+                if let Some(lookaheads) = parser_lookaheads.get(&name) {
+                    stack.extend(lookaheads.iter().cloned());
+                } else {
+                    stack.push(NextChar::Any);
+                }
             }
             NextChar::Any => {
                 chars.insert(None);

--- a/macros/src/codegen/lookahead_optimization.rs
+++ b/macros/src/codegen/lookahead_optimization.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 
 use crate::{
     codegen::generate_pattern_choice_parser, Modifier, ParserBlock, ParserFunction, Pattern,
@@ -189,7 +189,9 @@ fn get_fragment_lookahead(fragment: &PatternFragment) -> Vec<NextChar> {
             }
         }
         PatternFragment::CharFilter(_) => vec![NextChar::Any],
-        PatternFragment::ParserRef(ident) => vec![NextChar::ParserRef(ident.to_string())],
+        PatternFragment::ParserRef(path) => {
+            vec![NextChar::ParserRef(path.into_token_stream().to_string())]
+        }
         PatternFragment::Ignore(inner) => get_pattern_lookahead(&inner.pattern),
         PatternFragment::Span(inner) => get_pattern_list_lookahead(inner),
         PatternFragment::Nested(inner) => get_pattern_list_lookahead(inner),

--- a/macros/src/codegen/mod.rs
+++ b/macros/src/codegen/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use syn::{Result, Type, Visibility};
+use syn::{parse::Parse, Result, Type, TypeInfer, Visibility};
 
 use crate::{
     Modifier, ParserBlock, ParserDef, ParserFunction, Pattern, PatternFragment, PatternList,
@@ -534,15 +534,10 @@ fn fragment_type(fragment: &PatternFragment, parser_types: &HashMap<String, Type
         P::Span(_) => quote! {&str},
         P::CharRange(_) | P::CharGroup(_) | P::AnyChar | P::CharFilter(_) => quote! {char},
         P::Ignore(_) | P::Literal(_) | P::LiteralChar(_) => quote! {()},
-        P::ParserRef(ident) => {
-            let Some(typ) = parser_types.get(&ident.to_string()) else {
-                return Err(syn::Error::new_spanned(
-                    ident,
-                    "Reference to undefined parser",
-                ));
-            };
-            return Ok(typ.clone());
-        }
+        P::ParserRef(ident) => match parser_types.get(&ident.to_string()) {
+            Some(typ) => return Ok(typ.clone()),
+            None => quote!(_),
+        },
         P::Nested(PatternList::List(l)) => return list_type(l, parser_types),
         P::Nested(PatternList::Choices(c)) => return list_type(&c[0], parser_types),
         P::Annotated(attr) => return pattern_type(&attr.pattern, parser_types),

--- a/macros/src/codegen/mod.rs
+++ b/macros/src/codegen/mod.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
-use syn::{parse::Parse, Result, Type, TypeInfer, Visibility};
+use quote::{quote, ToTokens};
+use syn::{Result, Type, Visibility};
 
 use crate::{
     Modifier, ParserBlock, ParserDef, ParserFunction, Pattern, PatternFragment, PatternList,
@@ -101,7 +101,7 @@ fn generate_fragment_parser(
         PatternFragment::ParserRef(parser) => {
             let recovery = state
                 .wrapped_parsers
-                .get(&parser.to_string())
+                .get(&parser.to_token_stream().to_string())
                 .filter(|_| state.recover)
                 .map(|(open, close)| quote! { .recover_wrapped(#open, #close, 1000) });
 
@@ -534,10 +534,14 @@ fn fragment_type(fragment: &PatternFragment, parser_types: &HashMap<String, Type
         P::Span(_) => quote! {&str},
         P::CharRange(_) | P::CharGroup(_) | P::AnyChar | P::CharFilter(_) => quote! {char},
         P::Ignore(_) | P::Literal(_) | P::LiteralChar(_) => quote! {()},
-        P::ParserRef(ident) => match parser_types.get(&ident.to_string()) {
-            Some(typ) => return Ok(typ.clone()),
-            None => quote!(_),
-        },
+        P::ParserRef(path) => {
+            if let Some(ident) = path.get_ident() {
+                if let Some(typ) = parser_types.get(&ident.to_string()) {
+                    return Ok(typ.clone());
+                }
+            }
+            quote!(_)
+        }
         P::Nested(PatternList::List(l)) => return list_type(l, parser_types),
         P::Nested(PatternList::Choices(c)) => return list_type(&c[0], parser_types),
         P::Annotated(attr) => return pattern_type(&attr.pattern, parser_types),

--- a/macros/src/display.rs
+++ b/macros/src/display.rs
@@ -1,5 +1,5 @@
 use crate::{Modifier, Pattern, PatternFragment, PatternList};
-use quote::quote;
+use quote::{quote, ToTokens};
 
 impl ToString for Pattern {
     fn to_string(&self) -> String {
@@ -63,7 +63,7 @@ impl ToString for PatternFragment {
                 let filter = &filter.expr;
                 format!("{{{:?}}}", quote! {#filter}.to_string())
             }
-            PatternFragment::ParserRef(ident) => ident.to_string(),
+            PatternFragment::ParserRef(path) => path.to_token_stream().to_string().to_string(),
             PatternFragment::Ignore(ignored) => format!("#{}", ignored.pattern.to_string()),
             PatternFragment::Span(span) => format!("<{}>", span.to_string()),
             PatternFragment::Nested(nested) => format!("({})", nested.to_string()),

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -230,7 +230,7 @@ impl ParserMatch {
             .map(|name| {
                 vec![Pattern {
                     modifier: None,
-                    fragment: PatternFragment::ParserRef(name.clone()),
+                    fragment: PatternFragment::ParserRef(name.clone().into()),
                 }]
             })
             .collect();
@@ -377,7 +377,7 @@ pub(crate) enum PatternFragment {
     CharRange(CharRange),
     CharGroup(CharGroup),
     CharFilter(CharFilter),
-    ParserRef(Ident),
+    ParserRef(Path),
     Ignore(Box<IgnoredPattern>),
     Span(PatternList),
     Nested(PatternList),
@@ -425,8 +425,8 @@ impl Parse for PatternFragment {
             let patterns = input.parse()?;
             input.parse::<Token![>]>()?;
             Ok(PatternFragment::Span(patterns))
-        } else if input.peek(Ident) {
-            input.parse().map(PatternFragment::ParserRef)
+        } else if let Ok(path) = input.parse() {
+            Ok(PatternFragment::ParserRef(path))
         } else {
             Err(input.error("expected pattern fragment"))
         }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -209,4 +209,13 @@ mod tests {
             CustomError::Untwine(ParserError::UnexpectedToken)
         );
     }
+
+    parser! {
+        pub external = '[' num_list ']' -> Vec<u32>;
+    }
+
+    #[test]
+    fn test_external_parser() {
+        assert_eq!(parse(external, "[1234,6521]").unwrap(), vec![1234, 6521]);
+    }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -210,12 +210,20 @@ mod tests {
         );
     }
 
+    mod parser_module {
+        use super::*;
+
+        parser! {
+            pub ident = <{|c| c.is_ascii_alphabetic()} {|c| c.is_ascii_alphanumeric()}*> -> &str;
+        }
+    }
+
     parser! {
-        pub external = '[' num_list ']' -> Vec<u32>;
+        pub external: ident=parser_module::ident -> String { String::from(ident) }
     }
 
     #[test]
     fn test_external_parser() {
-        assert_eq!(parse(external, "[1234,6521]").unwrap(), vec![1234, 6521]);
+        assert_eq!(parse(external, "aaa").unwrap(), "aaa");
     }
 }


### PR DESCRIPTION
This PR allows referencing external parsers, so that splitting a complicated parser into multiple modules is possible:

```rust
mod external_parsers {
  untwine::parser! {
     pub util_parser = <"Some Parser"> -> &str;
  }
}

untwine::parser! {
   pub parser = external_parsers::util_parser -> &str;
}
```
